### PR TITLE
Add OGRWriter parameters

### DIFF
--- a/gdal_nodes.cpp
+++ b/gdal_nodes.cpp
@@ -226,7 +226,7 @@ void OGRWriterNode::process()
   {
     wkbType = wkbLineString25D;
   }
-  poLayer = poDS->CreateLayer("geom", &oSRS, wkbType, NULL);
+  poLayer = poDS->CreateLayer(layername.c_str(), &oSRS, wkbType, NULL);
   if (poLayer == NULL)
   {
     printf("Layer creation failed.\n");

--- a/gdal_nodes.cpp
+++ b/gdal_nodes.cpp
@@ -193,15 +193,14 @@ void OGRWriterNode::process()
   auto& geom_term = vector_input("geometries");
 
   //    const char *gszDriverName = "ESRI Shapefile";
-  const char *gszDriverName = "GPKG";
   GDALDriver *poDriver;
 
   GDALAllRegister();
 
-  poDriver = GetGDALDriverManager()->GetDriverByName(gszDriverName);
+  poDriver = GetGDALDriverManager()->GetDriverByName(gdaldriver.c_str());
   if (poDriver == NULL)
   {
-    printf("%s driver not available.\n", gszDriverName);
+    printf("%s driver not available.\n", gdaldriver.c_str());
     exit(1);
   }
 

--- a/gdal_nodes.hpp
+++ b/gdal_nodes.hpp
@@ -41,6 +41,7 @@ class OGRWriterNode : public Node
   int epsg = 7415;
   std::string filepath = "out";
   std::string gdaldriver = "GPKG";
+  std::string layername = "geom";
 
 public:
   using Node::Node;
@@ -52,6 +53,7 @@ public:
     add_param("filepath", ParamPath(filepath, "File path"));
     add_param("epsg", ParamInt(epsg, "EPSG"));
     add_param("gdaldriver", ParamString(gdaldriver, "GDAL driver (format)"));
+    add_param("layername", ParamString(layername, "Layer name"));
   }
   void process();
 };

--- a/gdal_nodes.hpp
+++ b/gdal_nodes.hpp
@@ -40,6 +40,7 @@ class OGRWriterNode : public Node
 {
   int epsg = 7415;
   std::string filepath = "out";
+  std::string gdaldriver = "GPKG";
 
 public:
   using Node::Node;
@@ -49,6 +50,8 @@ public:
     add_poly_input("attributes", {typeid(vec1b), typeid(vec1i), typeid(vec1f), typeid(vec1s)}, true);
 
     add_param("filepath", ParamPath(filepath, "File path"));
+    add_param("epsg", ParamInt(epsg, "EPSG"));
+    add_param("gdaldriver", ParamString(gdaldriver, "GDAL driver (format)"));
   }
   void process();
 };


### PR DESCRIPTION
Adds 'epgs', 'GDAL driver', 'layer name' parameters so it is possible to write any file/connection that GDAL supports, including PostGIS.

I didn't work on the geometry types, so still only linear rings are supported, which are converted to Polygons. 