### PR TITLE
Appending features to existing layer for OGRWriter

### DIFF
--- a/gdal_nodes.cpp
+++ b/gdal_nodes.cpp
@@ -264,12 +264,6 @@ void OGRWriterNode::process()
   // Driver creation options. For now there is only one option possible.
   //  char** papszOptions = (char**)CPLCalloc(sizeof(char*), 2);
   char** papszOptions = nullptr;
-  if (!overwrite_dataset) {
-    papszOptions = CSLSetNameValue(papszOptions, "APPEND_SUBDATASET", "YES");
-    poDS = (GDALDataset*) GDALDataset::Open(manager.substitute_globals(filepath).c_str(), GDAL_OF_VECTOR||GDAL_OF_UPDATE);
-  } else {
-    papszOptions = CSLSetNameValue(papszOptions, "APPEND_SUBDATASET", "NO");
-  }
   if (poDS == nullptr) {
     // Create the dataset
     poDS = poDriver->Create(manager.substitute_globals(filepath).c_str(),
@@ -279,12 +273,7 @@ void OGRWriterNode::process()
                             GDT_Unknown,
                             papszOptions);
   }
-  // std::string bla("APPEND_SUBDATASET=YES");
-  // CPLParseNameValue(bla.c_str(), nullptr);
-  // std::cout << std::endl
-  //           << "APPEND_SUBDATASET="
-  //           << CSLFetchNameValue(papszOptions, "APPEND_SUBDATASET")
-  //           << std::endl;
+
   if (poDS == nullptr) {
     printf("Creation of output file failed.\n");
     exit(1);
@@ -321,7 +310,10 @@ void OGRWriterNode::process()
   // TODO: appending features probably requires not creating a new layer, but instead getting the layer from the dataset with GetLayer()
   // overwrite existing layers
   char** lco = nullptr;
-  lco = CSLSetNameValue(lco, "OVERWRITE", "YES");
+  if (overwrite_dataset)
+    lco = CSLSetNameValue(lco, "OVERWRITE", "YES");
+  else
+    lco = CSLSetNameValue(lco, "OVERWRITE", "NO");
   poLayer = poDS->CreateLayer(manager.substitute_globals(layername).c_str(), &oSRS, wkbType, lco);
   if (poLayer == nullptr) {
     printf("Layer creation failed.\n");

--- a/gdal_nodes.cpp
+++ b/gdal_nodes.cpp
@@ -248,6 +248,9 @@ void OGRWriterNode::process()
     throw(gfException(gdaldriver + "driver not available"));
   }
 
+  bool overwrite = overwrite_;
+  bool append = append_;
+
   // For parsing GDAL KEY=VALUE options, see the CSL* functions in
   // https://gdal.org/api/cpl.html#cpl-string-h
 
@@ -257,7 +260,7 @@ void OGRWriterNode::process()
   if (append) {
     papszOptions = CSLSetNameValue(papszOptions, "APPEND_SUBDATASET", "YES");
     // If we append, we must overwrite too
-    overwrite_dataset = true;
+    overwrite = true;
   }
   else {
     papszOptions = CSLSetNameValue(papszOptions, "APPEND_SUBDATASET", "NO");
@@ -294,7 +297,7 @@ void OGRWriterNode::process()
   }
 
   char** lco = nullptr;
-  if (overwrite_dataset)
+  if (overwrite)
     lco = CSLSetNameValue(lco, "OVERWRITE", "YES");
   else
     lco = CSLSetNameValue(lco, "OVERWRITE", "NO");
@@ -308,8 +311,8 @@ void OGRWriterNode::process()
     // if the table doesn't exist. So we need to check for existing fields.
     fcnt = poLayer->GetLayerDefn()->GetFieldCount();
     if (fcnt == 0) {
-      append             = false;
-      overwrite_dataset  = false;
+      append = false;
+      overwrite  = false;
       bool tables_in_dsn = manager.substitute_globals(filepath).find(
                              "tables=") != std::string::npos;
       if (tables_in_dsn) {
@@ -321,8 +324,8 @@ void OGRWriterNode::process()
       }
     }
   } else {
-    append            = false;
-    overwrite_dataset = false;
+    append = false;
+    overwrite = false;
   }
 
   std::unordered_map<std::string, size_t> attr_id_map;

--- a/gdal_nodes.cpp
+++ b/gdal_nodes.cpp
@@ -242,7 +242,7 @@ void OGRWriterNode::on_receive(gfMultiFeatureInputTerminal& it) {
 void OGRWriterNode::process()
 {
   bool overwrite = overwrite_;
-  bool append = append_;
+  bool append = overwrite ? false : append_;
   std::string filepath = manager.substitute_globals(filepath_);
   std::string gdaldriver = manager.substitute_globals(gdaldriver_);
   std::string layername = manager.substitute_globals(layername_);

--- a/gdal_nodes.cpp
+++ b/gdal_nodes.cpp
@@ -200,8 +200,7 @@ void OGRLoaderNode::process()
 inline void create_field(OGRLayer* poLayer, std::string& name, OGRFieldType field_type) {
   OGRFieldDefn oField(name.c_str(), field_type);
   if (poLayer->CreateField(&oField) != OGRERR_NONE) {
-    printf("Creating field failed.\n");
-    exit(1);
+    throw(gfException("Creating field failed"));
   }
 }
 
@@ -246,8 +245,7 @@ void OGRWriterNode::process()
   GDALDriver* poDriver;
   poDriver = GetGDALDriverManager()->GetDriverByName(manager.substitute_globals(gdaldriver).c_str());
   if (poDriver == nullptr) {
-    printf("%s driver not available.\n", gdaldriver.c_str());
-    exit(1);
+    throw(gfException(gdaldriver + "driver not available"));
   }
 
   // For parsing GDAL KEY=VALUE options, see the CSL* functions in
@@ -279,8 +277,7 @@ void OGRWriterNode::process()
   }
 
   if (poDS == nullptr) {
-    printf("Creation of output file failed.\n");
-    exit(1);
+    throw(gfException("Creation of output file failed."));
   }
 
   OGRSpatialReference oSRS;
@@ -333,10 +330,8 @@ void OGRWriterNode::process()
     // overwrite or create, so field count needs to reset
     fcnt = 0;
     poLayer = poDS->CreateLayer(manager.substitute_globals(layername).c_str(), &oSRS, wkbType, lco);
-    if (poLayer == nullptr) {
-      printf("Layer creation failed for %s.\n",
-             manager.substitute_globals(layername).c_str());
-      exit(1);
+    if (poLayer == nullptr) {             
+      throw(gfException("Layer creation failed for " + manager.substitute_globals(layername)));
     }
     // Create GDAL feature attributes
     for (auto& term : poly_input("attributes").sub_terminals()) {
@@ -448,9 +443,7 @@ void OGRWriterNode::process()
     }
 
     if (poLayer->CreateFeature(poFeature) != OGRERR_NONE) {
-      printf("Failed to create feature in %s.\n",
-             manager.substitute_globals(gdaldriver).c_str());
-      exit(1);
+      throw(gfException("Failed to create feature in "+manager.substitute_globals(gdaldriver)));
     }
     OGRFeature::DestroyFeature(poFeature);
   }

--- a/gdal_nodes.cpp
+++ b/gdal_nodes.cpp
@@ -264,6 +264,17 @@ void OGRWriterNode::process()
   // Driver creation options. For now there is only one option possible.
   //  char** papszOptions = (char**)CPLCalloc(sizeof(char*), 2);
   char** papszOptions = nullptr;
+  if (append) {
+    papszOptions = CSLSetNameValue(papszOptions, "APPEND_SUBDATASET", "YES");
+    // If we append, we must overwrite too
+    overwrite_dataset = true;
+  }
+  else {
+    papszOptions = CSLSetNameValue(papszOptions, "APPEND_SUBDATASET", "NO");
+    // We can still overwrite the layer though
+  }
+  poDS = (GDALDataset*) GDALDataset::Open(manager.substitute_globals(filepath).c_str(), GDAL_OF_VECTOR||GDAL_OF_UPDATE);
+  std::cout << "filepath OUTPUT_SOURCE is " << filepath << std::endl;
   if (poDS == nullptr) {
     // Create the dataset
     poDS = poDriver->Create(manager.substitute_globals(filepath).c_str(),
@@ -314,6 +325,11 @@ void OGRWriterNode::process()
     lco = CSLSetNameValue(lco, "OVERWRITE", "YES");
   else
     lco = CSLSetNameValue(lco, "OVERWRITE", "NO");
+  for( auto&& _l: poDS->GetLayers() )
+  {
+    std::cout << "Layer"  << _l->GetName() << std::endl;
+    std::cout << "here" << std::endl;
+  }
   poLayer = poDS->CreateLayer(manager.substitute_globals(layername).c_str(), &oSRS, wkbType, lco);
   if (poLayer == nullptr) {
     printf("Layer creation failed.\n");

--- a/gdal_nodes.hpp
+++ b/gdal_nodes.hpp
@@ -43,7 +43,6 @@ class OGRWriterNode : public Node
   std::string filepath = "out";
   std::string gdaldriver = "GPKG";
   std::string layername = "geom";
-  std::string lco = "";
   bool overwrite_dataset = false;
   bool append = false;
 
@@ -63,7 +62,6 @@ public:
     add_param(ParamInt(epsg, "epsg", "EPSG"));
     add_param(ParamString(gdaldriver, "gdaldriver", "GDAL driver (format)"));
     add_param(ParamString(layername, "layername", "Layer name"));
-    add_param(ParamString(lco, "lco", "Layer creation options (comma separated)"));
     add_param(ParamBool(overwrite_dataset, "overwrite_dataset", "Overwrite dataset if it exists"));
     add_param(ParamBool(append, "append", "Append to the data set?"));
     add_param(ParamStrMap(output_attribute_names, key_options, "output_attribute_names", "Output attribute names"));

--- a/gdal_nodes.hpp
+++ b/gdal_nodes.hpp
@@ -45,7 +45,7 @@ class OGRWriterNode : public Node
   std::string layername = "geom";
   std::string lco = "";
   bool overwrite_dataset = false;
-  // bool append = false;
+  bool append = false;
 
   vec1s key_options;
   StrMap output_attribute_names;
@@ -65,7 +65,7 @@ public:
     add_param(ParamString(layername, "layername", "Layer name"));
     add_param(ParamString(lco, "lco", "Layer creation options (comma separated)"));
     add_param(ParamBool(overwrite_dataset, "overwrite_dataset", "Overwrite dataset if it exists"));
-    // add_param(ParamBool(append, "append", "Append to the data set?"));
+    add_param(ParamBool(append, "append", "Append to the data set?"));
     add_param(ParamStrMap(output_attribute_names, key_options, "output_attribute_names", "Output attribute names"));
 
     if (GDALGetDriverCount() == 0)

--- a/gdal_nodes.hpp
+++ b/gdal_nodes.hpp
@@ -40,11 +40,11 @@ public:
 class OGRWriterNode : public Node
 {
   int epsg = 7415;
-  std::string filepath = "out";
-  std::string gdaldriver = "GPKG";
-  std::string layername = "geom";
-  bool overwrite = false;
-  bool append = false;
+  std::string filepath_ = "out";
+  std::string gdaldriver_ = "GPKG";
+  std::string layername_ = "geom";
+  bool overwrite_ = false;
+  bool append_ = false;
 
   vec1s key_options;
   StrMap output_attribute_names;
@@ -58,12 +58,12 @@ public:
     add_vector_input("geometries", {typeid(LineString), typeid(LinearRing), typeid(TriangleCollection), typeid(Mesh)});
     add_poly_input("attributes", {typeid(bool), typeid(int), typeid(float), typeid(std::string)}, false);
 
-    add_param(ParamPath(filepath, "filepath", "File path"));
+    add_param(ParamPath(filepath_, "filepath", "File path"));
     add_param(ParamInt(epsg, "epsg", "EPSG"));
-    add_param(ParamString(gdaldriver, "gdaldriver", "GDAL driver (format)"));
-    add_param(ParamString(layername, "layername", "Layer name"));
-    add_param(ParamBool(overwrite, "overwrite", "Overwrite dataset if it exists"));
-    add_param(ParamBool(append, "append", "Append to the data set?"));
+    add_param(ParamString(gdaldriver_, "gdaldriver", "GDAL driver (format)"));
+    add_param(ParamString(layername_, "layername", "Layer name"));
+    add_param(ParamBool(overwrite_, "overwrite", "Overwrite dataset if it exists"));
+    add_param(ParamBool(append_, "append", "Append to the data set?"));
     add_param(ParamStrMap(output_attribute_names, key_options, "output_attribute_names", "Output attribute names"));
 
     if (GDALGetDriverCount() == 0)

--- a/gdal_nodes.hpp
+++ b/gdal_nodes.hpp
@@ -43,7 +43,7 @@ class OGRWriterNode : public Node
   std::string filepath = "out";
   std::string gdaldriver = "GPKG";
   std::string layername = "geom";
-  bool overwrite_dataset = false;
+  bool overwrite = false;
   bool append = false;
 
   vec1s key_options;
@@ -62,7 +62,7 @@ public:
     add_param(ParamInt(epsg, "epsg", "EPSG"));
     add_param(ParamString(gdaldriver, "gdaldriver", "GDAL driver (format)"));
     add_param(ParamString(layername, "layername", "Layer name"));
-    add_param(ParamBool(overwrite_dataset, "overwrite_dataset", "Overwrite dataset if it exists"));
+    add_param(ParamBool(overwrite, "overwrite", "Overwrite dataset if it exists"));
     add_param(ParamBool(append, "append", "Append to the data set?"));
     add_param(ParamStrMap(output_attribute_names, key_options, "output_attribute_names", "Output attribute names"));
 


### PR DESCRIPTION
+ Works for both overwriting and appending to a layer/table
+ Tested with postgres and gpkg

Specifics for postgres:
+ Use the `schemas=` option instead of `active_schema=` to limit the search path to a specific schema, because `active_schema=` gives an 'unable to connect' error when writing to a connection, but it still writes the data
+ When appending to a table, the table needs to be specified with the `tables=` option, including the schema name. Eg. `tables=schema_name.table_name`
+ When a new table is created, the `tables=schema_name.table_name` option is not respected, but the `layername` takes precedence, and the table is written to the `public` schema. Unless `schemas=` is specified or the layername is specified as `shema_name.table_name`.
+ In case you want to create a new table with some data, then keep adding to the same table in a specific schema (in consecutive runs of geoflow), then specify `schemas=schema_name_1 tables=schema_name_1.table_name`

Closes #6