### PR TITLE
Write untriangulated 3D geometry and building part id

### DIFF
--- a/gdal_nodes.hpp
+++ b/gdal_nodes.hpp
@@ -106,7 +106,7 @@ public:
   using Node::Node;
   void init()
   {
-    add_vector_input("geometries", {typeid(LineString), typeid(LinearRing), typeid(std::vector<TriangleCollection>), typeid(MultiTriangleCollection), typeid(Mesh)});
+    add_vector_input("geometries", {typeid(LineString), typeid(LinearRing), typeid(std::vector<TriangleCollection>), typeid(MultiTriangleCollection), typeid(Mesh), typeid(std::unordered_map<int, Mesh>)});
     add_poly_input("attributes", {typeid(bool), typeid(int), typeid(float), typeid(std::string)}, false);
 
     add_param(ParamPath(conn_string_, "filepath", "Connection string"));


### PR DESCRIPTION
Write the untriangulated Mesh collections to Postgis.

Assign the `building_part_id` attribute to the 3D layers, both triangulated and untriangulated.
For the Mesh collections the `building_part_id` is the index of the Mesh in the collection (L412).
For the MultiTriangleCollections the `building_part_id` is the index of the TriangleCollection (L376). @Ylannl could you verify if this is correct?

Compared to the cityjson writer which concatenates the `identificatie` withe the building_part_id to create the UID, here the building_part_id is kept separate, which is the same as in the 2D layers.

Needed for https://github.com/tudelft3d/3dbag-pipeline/issues/46