### PR TITLE
Fix GDAL open raster data set

### DIFF
--- a/ogr_writer_node.cpp
+++ b/ogr_writer_node.cpp
@@ -88,7 +88,7 @@ void OGRWriterNode::process()
   }
 
   GDALDataset* dataSource = nullptr;
-  dataSource = (GDALDataset*) GDALDataset::Open(connstr.c_str(), GDAL_OF_VECTOR||GDAL_OF_UPDATE);
+  dataSource = (GDALDataset*) GDALOpenEx(connstr.c_str(), GDAL_OF_VECTOR|GDAL_OF_UPDATE, NULL, NULL, NULL);
   if (dataSource == nullptr) {
     dataSource = driver->Create(connstr.c_str(), 0, 0, 0, GDT_Unknown, NULL);
   }


### PR DESCRIPTION
- Use GDALOpenEx instead of GDALDataset::Open, beause it is more modern, see https://gdal.org/development/rfc/rfc46_gdal_ogr_unification.html?highlight=nopenflags#drivers-and-driver-registration
- GDAL open needs bitwise OR instead of logical OR for the nOpenFlags otherwise it does not recognize the flags and tries to open a raster data set.

Fixes #24